### PR TITLE
Remove leading spaces from example setpass command

### DIFF
--- a/email/default/setpass
+++ b/email/default/setpass
@@ -14,7 +14,7 @@ change your password anyway.
 In order to set a new password, you must send the following command
 on IRC, where <password> is the new password you wish to set.
 
-   /msg &nicksvs& SETPASS &accountname& &param& <password>
+/msg &nicksvs& SETPASS &accountname& &param& <password>
 
 --
 If you have any questions, please contact &replyto&


### PR DESCRIPTION
Apparently some users have been pasting the entire line into their client and end up sending their intended new password to their current channel. Hopefully this change will help stop that.
