### PR TITLE
removed leading spaces

### DIFF
--- a/email/default/register
+++ b/email/default/register
@@ -9,7 +9,7 @@ Date: &date&
 In order to complete your account registration, you must type the following
 command on IRC:
 
-   /msg &nicksvs& VERIFY REGISTER &accountname& &param&
+/msg &nicksvs& VERIFY REGISTER &accountname& &param&
 
 Thank you for registering your account on the &netname& IRC network!
 


### PR DESCRIPTION
Users tend to double click on the line in their email client, highlighting the leading spaces and then pasting that into their client, leading to a few /msg nickserv VERIFY blah each day
