### PR TITLE
Add the "set quietpass" user option

### DIFF
--- a/dist/atheme.conf.example
+++ b/dist/atheme.conf.example
@@ -204,6 +204,7 @@ loadmodule "modules/crypto/posix";
  * SET PROPERTY command                         modules/nickserv/set_property
  * SET PUBKEY command                           modules/nickserv/set_pubkey
  * SET QUIETCHG command                         modules/nickserv/set_quietchg
+ * SET QUIETPASS command                        modules/nickserv/set_quietpass
  * Password retrieval uses code (SETPASS cmd)   modules/nickserv/setpass
  * STATUS command                               modules/nickserv/status
  * Nickname metadata viewer (TAXONOMY command)  modules/nickserv/taxonomy
@@ -260,6 +261,7 @@ loadmodule "modules/nickserv/set_password";
 loadmodule "modules/nickserv/set_property";
 loadmodule "modules/nickserv/set_pubkey";
 loadmodule "modules/nickserv/set_quietchg";
+loadmodule "modules/nickserv/set_quietpass";
 loadmodule "modules/nickserv/status";
 loadmodule "modules/nickserv/taxonomy";
 loadmodule "modules/nickserv/vacation";
@@ -1978,7 +1980,7 @@ general {
 	/* (*)uflags
 	 * The default flags to set for usernames upon registration.
 	 * Valid values are: hold, neverop, noop, hidemail, nomemo, emailmemos,
-	 * enforce, privmsg, private, quietchg and none.
+	 * enforce, privmsg, private, quietchg, quietpass and none.
 	 */
 	uflags = { hidemail; };
 

--- a/help/default/nickserv/list
+++ b/help/default/nickserv/list
@@ -24,6 +24,7 @@ NOMEMO        - All users with the NOMEMO flag set.
 EMAILMEMOS    - All users with the EMAILMEMOS flag set.
 USE-PRIVMSG   - All users with the USEPRIVMSG flag set.
 QUIETCHG      - All users with the QUIETCHG flag set.
+QUIETPASS     - All users with the QUIETPASS flag set.
 NOGREET       - All users with the NOGREET flag set.
 PRIVATE       - All users with the PRIVATE flag set.
 REGNOLIMIT    - All users with the REGNOLIMIT flag set.

--- a/help/default/nickserv/set_quietpass
+++ b/help/default/nickserv/set_quietpass
@@ -1,0 +1,17 @@
+Help for SET QUIETPASS:
+
+SET QUIETPASS prevents services from automatically
+notifying you when another user tries to log in as
+you without having the correct password. When set
+to ON, Services will no longer send you messages of
+this nature while you are logged in.
+
+When you connect, Services tells you anyway the
+number of such events that occurred since your last
+successful login. This includes the time where you
+were subsequently logged.
+
+Syntax: SET QUIETPASS ON|OFF
+
+Example:
+    /msg &nick& SET QUIETPASS ON

--- a/help/fr/nickserv/list
+++ b/help/fr/nickserv/list
@@ -21,6 +21,7 @@ NOMEMO        - Tous les utilisateurs avec le flag NOMEMO actif.
 EMAILMEMOS    - Tous les utilisateurs avec le flag EMAILMEMOS actif.
 USE-PRIVMSG   - Tous les utilisateurs avec le flag USEPRIVMSG actif.
 QUIETCHG      - Tous les utilisateurs avec le flag QUIETCHG actif.
+QUIETPASS     - Tous les utilisateurs avec le flag QUIETPASS actif.
 NOGREET       - Tous les utilisateurs avec le flag NOGREET actif.
 PRIVATE       - Tous les utilisateurs avec le flag PRIVATE actif.
 REGNOLIMIT    - Tous les utilisateurs avec le flag REGNOLIMIT actif.

--- a/help/fr/nickserv/set_quietpass
+++ b/help/fr/nickserv/set_quietpass
@@ -1,0 +1,19 @@
+Aide pour SET QUIETPASS:
+
+SET QUIETPASS empêche les services de vous notifier
+automatiquement lorsqu'un autre utilisateur tente de
+se logger sous votre nom, sans avoir le bon mot de
+passe. Lorsque ceci est défini à ON, les services
+ne vous enverront plus de messages de cette nature
+pendant que vous êtes connecté.
+
+Au moment de la connexion, les services vous notifient
+de toute manière du nombre de tels événements qui
+se sont produit depuis l'instant auquel votre connexion
+précédente a été établie. Cela inclus le temps
+pendant lequel vous étiez loggé.
+
+Syntaxe : SET QUIETPASS ON|OFF
+
+Exemple :
+    /msg &nick& SET QUIETPASS ON

--- a/include/account.h
+++ b/include/account.h
@@ -116,6 +116,7 @@ struct myuser_
 #define MU_REGNOLIMIT  0x00010000
 #define MU_NEVERGROUP  0x00020000
 #define MU_PENDINGLOGIN 0x00040000
+#define MU_QUIETPASS   0x00080000
 
 /* memoserv rate limiting parameters */
 #define MEMO_MAX_NUM   5

--- a/libathemecore/conf.c
+++ b/libathemecore/conf.c
@@ -61,6 +61,7 @@ static struct Token uflags[] = {
   { "PRIVATE",   MU_PRIVATE      },
   { "QUIETCHG",  MU_QUIETCHG     },
   { "NEVERGROUP", MU_NEVERGROUP  },
+  { "QUIETPASS", MU_QUIETPASS    },
   { "NONE",      0               },
   { NULL, 0 }
 };

--- a/libathemecore/flags.c
+++ b/libathemecore/flags.c
@@ -69,6 +69,7 @@ struct gflags mu_flags[] = {
 	{ 'g', MU_NOGREET },
 	{ 'r', MU_REGNOLIMIT },
 	{ 'N', MU_NEVERGROUP },
+	{ 'U', MU_QUIETPASS },
 	{ 0, 0 },
 };
 

--- a/libathemecore/services.c
+++ b/libathemecore/services.c
@@ -794,7 +794,7 @@ bool bad_password(sourceinfo_t *si, myuser_t *mu)
 	svs = si->service;
 	if (svs == NULL)
 		svs = service_find("nickserv");
-	if (svs != NULL)
+	if (svs != NULL && !(mu->flags & MU_QUIETPASS))
 	{
 		myuser_notice(svs->me->nick, mu, "\2%s\2 failed to login to \2%s\2.  There %s been \2%d\2 failed login %s since your last successful login.", mask, entity(mu)->name, count == 1 ? "has" : "have", count, count == 1 ? "attempt" : "attempts");
 	}

--- a/modules/nickserv/Makefile
+++ b/modules/nickserv/Makefile
@@ -59,6 +59,7 @@ BASE_SRCS =			\
 	set_property.c	\
 	set_pubkey.c	\
 	set_quietchg.c	\
+	set_quietpass.c	\
 	setpass.c	\
 	status.c	\
 	taxonomy.c	\

--- a/modules/nickserv/set.c
+++ b/modules/nickserv/set.c
@@ -36,6 +36,7 @@ void _modinit(module_t *m)
 	MODULE_TRY_REQUEST_DEPENDENCY(m, "nickserv/set_password");
 	MODULE_TRY_REQUEST_DEPENDENCY(m, "nickserv/set_property");
 	MODULE_TRY_REQUEST_DEPENDENCY(m, "nickserv/set_quietchg");
+	MODULE_TRY_REQUEST_DEPENDENCY(m, "nickserv/set_quietpass");
 }
 
 void _moddeinit(module_unload_intent_t intent)

--- a/modules/nickserv/set_quietpass.c
+++ b/modules/nickserv/set_quietpass.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2005 William Pitcock <nenolod -at- nenolod.net>
+ * Copyright (c) 2007 Jilles Tjoelker
+ * Rights to this code are as documented in doc/LICENSE.
+ *
+ * Allows you to opt-out of channel change messages.
+ *
+ */
+
+#include "atheme.h"
+#include "uplink.h"
+#include "list_common.h"
+#include "list.h"
+
+DECLARE_MODULE_V1
+(
+	"nickserv/set_quietpass", false, _modinit, _moddeinit,
+	PACKAGE_STRING,
+	"Atheme Development Group <http://www.atheme.org>"
+);
+
+mowgli_patricia_t **ns_set_cmdtree;
+
+static void ns_cmd_set_quietpass(sourceinfo_t *si, int parc, char *parv[]);
+
+command_t ns_set_quietpass = { "QUIETPASS", N_("Opt-out of bad password messages from others."), AC_NONE, 1, ns_cmd_set_quietpass, { .path = "nickserv/set_quietpass" } };
+
+static bool has_quietpass(const mynick_t *mn, const void *arg)
+{
+	myuser_t *mu = mn->owner;
+
+	return ( mu->flags & MU_QUIETPASS ) == MU_QUIETPASS;
+}
+
+void _modinit(module_t *m)
+{
+	MODULE_TRY_REQUEST_SYMBOL(m, ns_set_cmdtree, "nickserv/set_core", "ns_set_cmdtree");
+
+	command_add(&ns_set_quietpass, *ns_set_cmdtree);
+
+	use_nslist_main_symbols(m);
+
+	static list_param_t quietpass;
+	quietpass.opttype = OPT_BOOL;
+	quietpass.is_match = has_quietpass;
+
+	list_register("quietpass", &quietpass);
+}
+
+void _moddeinit(module_unload_intent_t intent)
+{
+	command_delete(&ns_set_quietpass, *ns_set_cmdtree);
+
+	list_unregister("quietpass");
+}
+
+/* SET QUIETPASS [ON|OFF] */
+static void ns_cmd_set_quietpass(sourceinfo_t *si, int parc, char *parv[])
+{
+	char *setting = parv[0];
+
+	if (!setting)
+	{
+		command_fail(si, fault_needmoreparams, STR_INSUFFICIENT_PARAMS, "QUIETPASS");
+		return;
+	}
+
+	if (!strcasecmp("ON", setting))
+	{
+		if (MU_QUIETPASS & si->smu->flags)
+		{
+			command_fail(si, fault_nochange, _("The \2%s\2 flag is already set for account \2%s\2."), "QUIETPASS", entity(si->smu)->name);
+			return;
+		}
+
+		logcommand(si, CMDLOG_SET, "SET:QUIETPASS:ON");
+
+		si->smu->flags |= MU_QUIETPASS;
+
+		command_success_nodata(si, _("The \2%s\2 flag has been set for account \2%s\2."), "QUIETPASS" ,entity(si->smu)->name);
+
+		return;
+	}
+	else if (!strcasecmp("OFF", setting))
+	{
+		if (!(MU_QUIETPASS & si->smu->flags))
+		{
+			command_fail(si, fault_nochange, _("The \2%s\2 flag is not set for account \2%s\2."), "QUIETPASS", entity(si->smu)->name);
+			return;
+		}
+
+		logcommand(si, CMDLOG_SET, "SET:QUIETPASS:OFF");
+
+		si->smu->flags &= ~MU_QUIETPASS;
+
+		command_success_nodata(si, _("The \2%s\2 flag has been removed for account \2%s\2."), "QUIETPASS", entity(si->smu)->name);
+
+		return;
+	}
+	else
+	{
+		command_fail(si, fault_badparams, STR_INVALID_PARAMS, "QUIETPASS");
+		return;
+	}
+}
+
+/* vim:cinoptions=>s,e0,n0,f0,{0,}0,^0,=s,ps,t0,c3,+s,(2s,us,)20,*30,gs,hs
+ * vim:ts=8
+ * vim:sw=8
+ * vim:noexpandtab
+ */

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -192,6 +192,7 @@ modules/nickserv/set_private.c
 modules/nickserv/set_privmsg.c
 modules/nickserv/set_property.c
 modules/nickserv/set_quietchg.c
+modules/nickserv/set_quietpass.c
 modules/nickserv/status.c
 modules/nickserv/taxonomy.c
 modules/nickserv/vacation.c


### PR DESCRIPTION
SET QUIETPASS prevents services from automatically notifying you when another user tries to log in as you without having the correct password.

When you connect, Services tells you anyway the number of such events that occurred since your last successful login. This includes the time where you were subsequently logged.
