### PR TITLE
Fix a blunder in documentation

### DIFF
--- a/help/default/alis/list
+++ b/help/default/alis/list
@@ -20,7 +20,7 @@ The pattern can contain * and ? wildcards. The pattern has to
 match the full channel name or a full topic, depending on where it
 is used; the wildcards are important. The pattern is also
 automatically surrounded by * wildcards if
-- a channel name pattern starts with a wildcard or a #, or
+- a channel name pattern does not start with a wildcard or a #, or
 - a topic pattern contains no * wildcards.
 
 For example, for channel names, from most to least specific:


### PR DESCRIPTION
I think the help should say "- a channel name pattern does not start with a wildcard or a #, or" instead of "- a channel name pattern starts with a wildcard or a #, or"

Relevant code

https://github.com/atheme/atheme/blob/master/modules/alis/main.c#L135

Brought up by ccat at #freenode on 28 April 2017, merged into atheme in commit 2fbcdf4 a few months ago